### PR TITLE
feat(velocity): migrate config handling from BungeeCord API to SnakeYAML

### DIFF
--- a/yuanluServerDo-velocity/pom.xml
+++ b/yuanluServerDo-velocity/pom.xml
@@ -69,12 +69,12 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/net.md-5/bungeecord-api -->
+        <!-- SnakeYAML is provided by Velocity at runtime -->
         <dependency>
-            <groupId>net.md-5</groupId>
-            <artifactId>bungeecord-config</artifactId>
-            <version>1.16-R0.5-SNAPSHOT</version>
-            <scope>compile</scope>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+            <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.bstats/bstats-velocity -->
         <dependency>

--- a/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/ConfigManager.java
+++ b/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/ConfigManager.java
@@ -7,9 +7,6 @@ import com.google.common.base.Objects;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ServerConnection;
 import lombok.*;
-import net.md_5.bungee.config.Configuration;
-import net.md_5.bungee.config.ConfigurationProvider;
-import net.md_5.bungee.config.YamlConfiguration;
 import yuan.plugins.serverDo.*;
 import yuan.plugins.serverDo.Tool.ThrowableFunction;
 import yuan.plugins.serverDo.Tool.ThrowableRunnable;
@@ -34,7 +31,7 @@ public final class ConfigManager {
 	/** 禁用的服务器 */
 	private static final   HashSet<String>                  BAN_SERVER = new HashSet<>();
 	/** 配置文件 */
-	private static @Getter Configuration                    config;
+	private static @Getter YamlConfig                        config;
 	/** tab替换 */
 	private static @Getter
 	@Setter                String                           tabReplace;
@@ -101,7 +98,7 @@ public final class ConfigManager {
 	 *
 	 * @param config config
 	 */
-	public static void init(Configuration config) {
+	public static void init(YamlConfig config) {
 		ConfigManager.config = config;
 		val tabReplace = config.getString("player-tab-replace", "yl★:" + Tool.randomString(8));
 		setTabReplace(tabReplace);
@@ -120,7 +117,7 @@ public final class ConfigManager {
 	 *
 	 * @param config 配置文件
 	 */
-	private static void loadGroup(Configuration config) {
+	private static void loadGroup(YamlConfig config) {
 		val sg = config.getSection("server-group");
 		if (sg == null) {
 			errorGroup = true;
@@ -176,11 +173,11 @@ public final class ConfigManager {
 	}
 
 	/**
-	 * 发送BC信息给子服务器
+	 * 发送代理信息给子服务器
 	 *
 	 * @param server 服务器
 	 */
-	public static void sendBungeeInfoToServer(ServerConnection server) {
+	public static void sendVelocityInfoToServer(ServerConnection server) {
 		Main.send(server, serverInfo);
 	}
 
@@ -223,9 +220,9 @@ public final class ConfigManager {
 		WARP("warp.yml") {
 			@Override
 			protected void load0() throws IOException {
-				Configuration warps = YAML.load(getFile());
+				YamlConfig warps = YamlConfig.load(getFile());
 				for (String name : warps.getKeys()) {
-					Configuration warp = warps.getSection(name);
+					YamlConfig warp = warps.getSection(name);
 
 					String world = warp.getString("world", null);
 					String server = warp.getString("server", null);
@@ -244,7 +241,7 @@ public final class ConfigManager {
 
 			@Override
 			protected void save0() throws IOException {
-				Configuration warps = new Configuration();
+				YamlConfig warps = new YamlConfig();
 				for (Map.Entry<String, ShareLocation> e : WARPS.entrySet()) {
 					String name = e.getKey();
 					ShareLocation warp = e.getValue();
@@ -256,13 +253,11 @@ public final class ConfigManager {
 					warps.set(name + ".yaw", warp.getYaw());
 					warps.set(name + ".pitch", warp.getPitch());
 				}
-				YAML.save(warps, getFile());
+				YamlConfig.save(warps, getFile());
 			}
 
 		};
 
-		/** Yaml处理器 */
-		protected static final ConfigurationProvider   YAML       = ConfigurationProvider.getProvider(YamlConfiguration.class);
 		/** 保存延时 */
 		private static final   EnumMap<ConfFile, Long> SAVE_DELAY = new EnumMap<>(ConfFile.class);
 		/** 文件名 */
@@ -333,8 +328,6 @@ public final class ConfigManager {
 			}
 		};
 
-		/** Yaml处理器 */
-		protected static final ConfigurationProvider         YAML       = ConfigurationProvider.getProvider(YamlConfiguration.class);
 		/** 文件名 */
 		protected final        String                        fname;
 		/** 需要保存 */
@@ -443,7 +436,7 @@ public final class ConfigManager {
 		private HashMap<String, ShareLocation> load0(@NonNull UUID uid) throws IOException {
 			HashMap<String, ShareLocation> m = new HashMap<>();
 			val f = HOME.getFile(uid, false);
-			val warps = PlayerConfFile.YAML.load(f);
+			val warps = YamlConfig.load(f);
 			for (val name : warps.getKeys()) {
 				val warp = warps.getSection(name);
 
@@ -473,7 +466,7 @@ public final class ConfigManager {
 		 * @throws IOException IOE
 		 */
 		private void save0(@NonNull UUID uid, HashMap<String, ShareLocation> map) throws IOException {
-			val warps = new Configuration();
+			val warps = new YamlConfig();
 			for (val e : map.entrySet()) {
 				val name = e.getKey();
 				val warp = e.getValue();
@@ -485,7 +478,7 @@ public final class ConfigManager {
 				warps.set(name + ".yaw", warp.getYaw());
 				warps.set(name + ".pitch", warp.getPitch());
 			}
-			PlayerConfFile.YAML.save(warps, PlayerConfFile.HOME.getFile(uid, true));
+			YamlConfig.save(warps, PlayerConfFile.HOME.getFile(uid, true));
 		}
 	}
 }

--- a/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/Core.java
+++ b/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/Core.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 /**
- * BC端核心
+ * Velocity端核心
  *
  * @author yuanlu
  */

--- a/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/Main.java
+++ b/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/Main.java
@@ -28,9 +28,6 @@ import com.velocitypowered.api.scheduler.ScheduledTask;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.val;
-import net.md_5.bungee.config.Configuration;
-import net.md_5.bungee.config.ConfigurationProvider;
-import net.md_5.bungee.config.YamlConfiguration;
 import org.bstats.charts.MultiLineChart;
 import org.bstats.charts.SimplePie;
 import org.bstats.velocity.Metrics;
@@ -55,8 +52,8 @@ import java.util.logging.Logger;
 public final class Main {
 	/** 插件名称 用于信息提示 模板自动生成 */
 	public final static    String                         SHOW_NAME    = ShareData.SHOW_NAME;
-	/** BC通道标识符: {@link ShareData#BC_CHANNEL} */
-	public static final    ChannelIdentifier              BC_CHANNEL   = new LegacyChannelIdentifier(ShareData.BC_CHANNEL);
+	/** 代理通道标识符: {@link ShareData#BC_CHANNEL} */
+	public static final    ChannelIdentifier              PROXY_CHANNEL = new LegacyChannelIdentifier(ShareData.BC_CHANNEL);
 	/** 数据包队列 */
 	private static final   Map<ServerInfo, Queue<byte[]>> PACKET_QUEUE = new HashMap<>();
 	/** 调试模式 */
@@ -204,7 +201,7 @@ public final class Main {
 	 * @param buf    数据
 	 */
 	public static void send(@NonNull ServerConnection server, @NonNull byte[] buf) {
-		server.sendPluginMessage(BC_CHANNEL, buf);
+		server.sendPluginMessage(PROXY_CHANNEL, buf);
 		if (isDEBUG()) getMain().getLogger().info("发送: " + server.getServerInfo().getName() + " " + Arrays.toString(buf));
 	}
 
@@ -272,10 +269,10 @@ public final class Main {
 	/** 检查中央配置文件 */
 	private void checkYuanluConfig() {
 		val configFile = getDataFolder().getParent().resolve("yuanlu").resolve("config.yml");
-		Configuration config = null;
+		YamlConfig config = null;
 
 		if (Files.isRegularFile(configFile)) try (val in = Files.newInputStream(configFile)) {
-			config = ConfigurationProvider.getProvider(YamlConfiguration.class).load(in);
+			config = YamlConfig.load(in);
 		} catch (FileNotFoundException ignored) {
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -292,7 +289,7 @@ public final class Main {
 
 	/**
 	 * 登录事件<br>
-	 * 唤起数据包发送队列(对应bc的send.queue实现)
+	 * 唤起数据包发送队列
 	 *
 	 * @param event ServerConnectedEvent
 	 *
@@ -323,7 +320,7 @@ public final class Main {
 	 *
 	 * @param e 插件消息
 	 *
-	 * @deprecated BUNGEE
+	 * @deprecated EVENT
 	 */
 	@Deprecated
 	@Subscribe
@@ -432,7 +429,7 @@ public final class Main {
 		ConfigManager.init(loadFile("proxy-config.yml"));
 		// 注册信道
 
-		getProxy().getChannelRegistrar().register(BC_CHANNEL);
+		getProxy().getChannelRegistrar().register(PROXY_CHANNEL);
 		getLogger().info(SHOW_NAME + "-启动(velocity)");
 		getLogger().info(Main.getPluginContainer().getDescription().getVersion().orElse("Unknown"));
 
@@ -465,7 +462,7 @@ public final class Main {
 	public void event_onServerPostConnect(ServerPostConnectEvent e) {
 		val server = e.getPlayer().getCurrentServer().orElseThrow(NullPointerException::new);
 		send(server, Channel.VersionCheck.sendS());
-		ConfigManager.sendBungeeInfoToServer(server);
+		ConfigManager.sendVelocityInfoToServer(server);
 		Core.autoVanish(e.getPlayer(), server);
 	}
 
@@ -478,7 +475,7 @@ public final class Main {
 	 *
 	 * @author yuanlu
 	 */
-	public Configuration loadFile(String fileName) {
+	public YamlConfig loadFile(String fileName) {
 		try {
 			val file = getDataFolder().resolve(fileName);
 			if (!Files.exists(file.getParent())) Files.createDirectories(file.getParent());
@@ -491,7 +488,7 @@ public final class Main {
 				}
 			}
 			try (val in = Files.newInputStream(file)) {
-				return ConfigurationProvider.getProvider(YamlConfiguration.class).load(in);
+				return YamlConfig.load(in);
 			}
 		} catch (RuntimeException e) {
 			throw e;
@@ -510,7 +507,7 @@ public final class Main {
 	 *
 	 * @author yuanlu
 	 */
-	public Configuration loadFile(String fileName, String... oldNames) {
+	public YamlConfig loadFile(String fileName, String... oldNames) {
 
 		val file = getDataFolder().resolve(fileName);
 		if (Files.isRegularFile(file)) return loadFile(fileName);
@@ -700,7 +697,7 @@ public final class Main {
 					m.createConnectionRequest(targetServer);
 					player.createConnectionRequest(targetServer).connect().thenAcceptAsync(r -> {
 						val success = r.getStatus() == Status.SUCCESS || r.getStatus() == Status.ALREADY_CONNECTED;
-						send(player, Channel.Tp.s7S_tpThirdReceive(success, false/* design for BC */));
+						send(player, Channel.Tp.s7S_tpThirdReceive(success, false/* design for proxy */));
 					});
 				}
 			});

--- a/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/YamlConfig.java
+++ b/yuanluServerDo-velocity/src/main/java/yuan/plugins/serverDo/velocity/YamlConfig.java
@@ -1,0 +1,195 @@
+package yuan.plugins.serverDo.velocity;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 基于 SnakeYAML 的轻量配置封装，用于替代旧代理端配置 API。
+ * 保留原项目常用的 getString/getSection/getKeys/set 等调用风格。
+ *
+ * @author H_aaa
+ */
+public final class YamlConfig {
+	private final Map<String, Object> root;
+
+	public YamlConfig() {
+		this.root = new LinkedHashMap<>();
+	}
+
+	private YamlConfig(Map<String, Object> root) {
+		this.root = root == null ? new LinkedHashMap<>() : root;
+	}
+
+	public static YamlConfig load(File file) throws IOException {
+		if (!file.exists()) throw new FileNotFoundException(file.getAbsolutePath());
+		try (InputStream in = new FileInputStream(file)) {
+			return load(in);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public static YamlConfig load(InputStream in) throws IOException {
+		LoaderOptions loaderOptions = new LoaderOptions();
+		Yaml yaml = new Yaml(new SafeConstructor(loaderOptions));
+		try (Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+			Object data = yaml.load(reader);
+			if (data == null) return new YamlConfig();
+			if (!(data instanceof Map)) throw new IOException("Yaml root is not a map");
+			return new YamlConfig(toStringObjectMap((Map<?, ?>) data));
+		}
+	}
+
+	public static void save(YamlConfig config, File file) throws IOException {
+		File parent = file.getParentFile();
+		if (parent != null && !parent.exists()) parent.mkdirs();
+		try (Writer writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
+			createYaml().dump(config.root, writer);
+		}
+	}
+
+	private static Yaml createYaml() {
+		DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		options.setPrettyFlow(true);
+		options.setIndent(2);
+		Representer representer = new Representer(options);
+		return new Yaml(representer, options);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> toStringObjectMap(Map<?, ?> input) {
+		Map<String, Object> result = new LinkedHashMap<>();
+		for (Map.Entry<?, ?> entry : input.entrySet()) {
+			String key = String.valueOf(entry.getKey());
+			Object value = entry.getValue();
+			if (value instanceof Map) value = toStringObjectMap((Map<?, ?>) value);
+			else if (value instanceof List) value = convertList((List<?>) value);
+			result.put(key, value);
+		}
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<Object> convertList(List<?> input) {
+		List<Object> result = new ArrayList<>();
+		for (Object value : input) {
+			if (value instanceof Map) result.add(toStringObjectMap((Map<?, ?>) value));
+			else if (value instanceof List) result.add(convertList((List<?>) value));
+			else result.add(value);
+		}
+		return result;
+	}
+
+	public Set<String> getKeys() {
+		return root.keySet();
+	}
+
+	public YamlConfig getSection(String path) {
+		Object value = get(path);
+		if (!(value instanceof Map)) return null;
+		@SuppressWarnings("unchecked")
+		Map<String, Object> map = (Map<String, Object>) value;
+		return new YamlConfig(map);
+	}
+
+	public String getString(String path, String def) {
+		Object value = get(path);
+		return value == null ? def : String.valueOf(value);
+	}
+
+	public long getLong(String path, long def) {
+		Object value = get(path);
+		if (value instanceof Number) return ((Number) value).longValue();
+		if (value instanceof String) try {
+			return Long.parseLong((String) value);
+		} catch (NumberFormatException ignored) {
+		}
+		return def;
+	}
+
+	public boolean getBoolean(String path, boolean def) {
+		Object value = get(path);
+		if (value instanceof Boolean) return (Boolean) value;
+		if (value instanceof String) return Boolean.parseBoolean((String) value);
+		return def;
+	}
+
+	public double getDouble(String path, double def) {
+		Object value = get(path);
+		if (value instanceof Number) return ((Number) value).doubleValue();
+		if (value instanceof String) try {
+			return Double.parseDouble((String) value);
+		} catch (NumberFormatException ignored) {
+		}
+		return def;
+	}
+
+	public float getFloat(String path, float def) {
+		Object value = get(path);
+		if (value instanceof Number) return ((Number) value).floatValue();
+		if (value instanceof String) try {
+			return Float.parseFloat((String) value);
+		} catch (NumberFormatException ignored) {
+		}
+		return def;
+	}
+
+	public List<String> getStringList(String path) {
+		Object value = get(path);
+		if (!(value instanceof List)) return Collections.emptyList();
+		List<String> result = new ArrayList<>();
+		for (Object item : (List<?>) value) if (item != null) result.add(String.valueOf(item));
+		return result;
+	}
+
+	public Object get(String path) {
+		String[] parts = path.split("\\.");
+		Object current = root;
+		for (String part : parts) {
+			if (!(current instanceof Map)) return null;
+			@SuppressWarnings("unchecked")
+			Map<String, Object> map = (Map<String, Object>) current;
+			current = map.get(part);
+			if (current == null) return null;
+		}
+		return current;
+	}
+
+	public void set(String path, Object value) {
+		String[] parts = path.split("\\.");
+		Map<String, Object> current = root;
+		for (int i = 0; i < parts.length - 1; i++) {
+			String part = parts[i];
+			Object next = current.get(part);
+			if (!(next instanceof Map)) {
+				next = new LinkedHashMap<String, Object>();
+				current.put(part, next);
+			}
+			@SuppressWarnings("unchecked")
+			Map<String, Object> nextMap = (Map<String, Object>) next;
+			current = nextMap;
+		}
+		current.put(parts[parts.length - 1], value);
+	}
+}


### PR DESCRIPTION
- remove net.md_5.bungee.config usage from Velocity module
- add SnakeYAML-based YamlConfig wrapper
- replace ConfigurationProvider/YamlConfiguration load-save logic
- update proxy config, warp config, and home config read/write flow
- keep existing config structure and business logic unchanged
- rename Bungee info send method to Velocity-oriented naming
- add SnakeYAML dependency snippet

已通过Velocity3.x系列测试

This PR fixes #15  